### PR TITLE
Fix highlighting on internal vs user defined types

### DIFF
--- a/syntaxes/temple.tmLanguage.json
+++ b/syntaxes/temple.tmLanguage.json
@@ -1,253 +1,253 @@
 {
-  "scopeName": "root.temple",
-  "patterns": [
-    {
-      "include": "#comments"
+    "patterns": [
+        {
+            "include": "#comments"
+        },
+        {
+            "include": "#blockType"
+        },
+        {
+            "include": "#builtInAttribute"
+        },
+        {
+            "include": "#userDefinedAttribute"
+        },
+        {
+            "include": "#metadata"
+        }
+    ],
+    "repository": {
+        "annotation": {
+            "match": "@[a-z][A-Za-z0-9_]*",
+            "name": "keyword"
+        },
+        "argsList": {
+            "begin": "\\(",
+            "end": "\\)",
+            "patterns": [
+                {
+                    "include": "#comments"
+                },
+                {
+                    "include": "#token"
+                },
+                {
+                    "include": "#numeric"
+                },
+                {
+                    "include": "#param"
+                }
+            ]
+        },
+        "blockType": {
+            "captures": {
+                "1": {
+                    "name": "entity.name.class"
+                },
+                "2": {
+                    "name": "comment.block"
+                },
+                "3": {
+                    "name": "comment.block"
+                },
+                "4": {
+                    "name": "keyword.other"
+                },
+                "5": {
+                    "name": "comment.block"
+                }
+            },
+            "match": "(?x)\n  ([A-Z][A-Za-z0-9_]*) # class name\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  : #colon\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  (target|project|service|struct) # block type name\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  \\{ # open brace\n"
+        },
+        "builtInAttribute": {
+            "begin": "(?x)\n  ([a-z][A-Za-z0-9_]*) # field name\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  : # colon\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  (bool|string|int|float|datetime|date|time|data) # type name\n",
+            "beginCaptures": {
+                "1": {
+                    "name": "entity.name"
+                },
+                "2": {
+                    "name": "comment.block"
+                },
+                "3": {
+                    "name": "comment.block"
+                },
+                "4": {
+                    "name": "support.type"
+                }
+            },
+            "end": "(?x)\n  (;|(?=((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*))\\}) # semicolon or end of block\n",
+            "patterns": [
+                {
+                    "include": "#argsList"
+                },
+                {
+                    "include": "#annotation"
+                },
+                {
+                    "include": "#comments"
+                },
+                {
+                    "include": "#numeric"
+                }
+            ]
+        },
+        "comments": {
+            "patterns": [
+                {
+                    "match": "//.*",
+                    "name": "comment.line.double-slash"
+                },
+                {
+                    "match": "/\\*[\\s\\S]*?\\*/",
+                    "name": "comment.block"
+                }
+            ]
+        },
+        "emptyMetadata": {
+            "captures": {
+                "1": {
+                    "name": "keyword"
+                }
+            },
+            "match": "(?x)\n  (\\#[a-z][A-Za-z0-9_]*) # hash followed by an identifier\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  (;|(?=((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*))\\}) # semicolon or end of block\n"
+        },
+        "fullMetadata": {
+            "begin": "(?x)\n  (\\#[a-z][A-Za-z0-9_]*) # hash followed by an identifier\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  \\( # open arg list\n",
+            "beginCaptures": {
+                "1": {
+                    "name": "keyword"
+                },
+                "2": {
+                    "name": "comment.block"
+                },
+                "3": {
+                    "name": "comment.block"
+                },
+                "4": {
+                    "name": "entity.name.type"
+                },
+                "5": {
+                    "name": "comment.block"
+                }
+            },
+            "end": "(?x)\n  \\) # close arg list\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  (;|(?=((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*))\\}) # semicolon or end of block\n",
+            "endCaptures": {
+                "1": {
+                    "name": "comment.block"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#comments"
+                },
+                {
+                    "include": "#token"
+                },
+                {
+                    "include": "#numeric"
+                },
+                {
+                    "include": "#param"
+                }
+            ]
+        },
+        "metadata": {
+            "patterns": [
+                {
+                    "include": "#fullMetadata"
+                },
+                {
+                    "include": "#shorthandMetadata"
+                },
+                {
+                    "include": "#emptyMetadata"
+                }
+            ]
+        },
+        "numeric": {
+            "match": "[-+]?\\d+(\\.\\d+)?",
+            "name": "constant.numeric"
+        },
+        "param": {
+            "captures": {
+                "1": {
+                    "name": "variable.parameter"
+                },
+                "2": {
+                    "name": "comment.block"
+                }
+            },
+            "match": "(?x)\n  ([a-zA-Z_][a-zA-Z_0-9]*) # identifier name\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  : # colon\n"
+        },
+        "shorthandMetadata": {
+            "begin": "(?x)\n  (\\#[a-z][A-Za-z0-9_]*) # hash followed by an identifier\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  \\[ # open shorthand\n",
+            "beginCaptures": {
+                "1": {
+                    "name": "keyword"
+                },
+                "2": {
+                    "name": "comment.block"
+                },
+                "3": {
+                    "name": "comment.block"
+                },
+                "4": {
+                    "name": "entity.name.type"
+                },
+                "5": {
+                    "name": "comment.block"
+                }
+            },
+            "end": "(?x)\n  \\] # close shorthand\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  (;|(?=((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*))\\}) # semicolon or end of block\n",
+            "endCaptures": {
+                "1": {
+                    "name": "comment.block"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#comments"
+                },
+                {
+                    "include": "#token"
+                },
+                {
+                    "include": "#numeric"
+                }
+            ]
+        },
+        "userDefinedAttribute": {
+            "begin": "(?x)\n  ([a-z][A-Za-z0-9_]*) # field name\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  : # colon\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  ([A-Z][A-Za-z0-9_]*) # type name\n",
+            "beginCaptures": {
+                "1": {
+                    "name": "entity.name"
+                },
+                "2": {
+                    "name": "comment.block"
+                },
+                "3": {
+                    "name": "comment.block"
+                },
+                "4": {
+                    "name": "entity.name.class"
+                }
+            },
+            "end": "(?x)\n  (;|(?=((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*))\\}) # semicolon or end of block\n",
+            "patterns": [
+                {
+                    "include": "#argsList"
+                },
+                {
+                    "include": "#annotation"
+                },
+                {
+                    "include": "#comments"
+                },
+                {
+                    "include": "#numeric"
+                }
+            ]
+        }
     },
-    {
-      "include": "#blockType"
-    },
-    {
-      "include": "#builtInAttribute"
-    },
-    {
-      "include": "#userDefinedAttribute"
-    },
-    {
-      "include": "#metadata"
-    }
-  ],
-  "repository": {
-    "blockType": {
-      "match": "(?x)\n  ([A-Z][A-Za-z0-9_]*) # class name\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  : #colon\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  (target|project|service|struct) # block type name\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  \\{ # open brace\n",
-      "captures": {
-        "1": {
-          "name": "entity.name.class"
-        },
-        "2": {
-          "name": "comment.block"
-        },
-        "3": {
-          "name": "comment.block"
-        },
-        "4": {
-          "name": "keyword.other"
-        },
-        "5": {
-          "name": "comment.block"
-        }
-      }
-    },
-    "annotation": {
-      "match": "@[a-z][A-Za-z0-9_]*",
-      "name": "keyword"
-    },
-    "comments": {
-      "patterns": [
-        {
-          "match": "//.*",
-          "name": "comment.line.double-slash"
-        },
-        {
-          "match": "/\\*[\\s\\S]*?\\*/",
-          "name": "comment.block"
-        }
-      ]
-    },
-    "builtInAttribute": {
-      "begin": "(?x)\n  ([a-z][A-Za-z0-9_]*) # field name\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  : # colon\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  (bool|string|int|float|datetime|date|time|data) # type name\n",
-      "beginCaptures": {
-        "1": {
-          "name": "entity.name"
-        },
-        "2": {
-          "name": "comment.block"
-        },
-        "3": {
-          "name": "comment.block"
-        },
-        "4": {
-          "name": "support.type"
-        }
-      },
-      "end": "(?x)\n  (;|(?=((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*))\\}) # semicolon or end of block\n",
-      "patterns": [
-        {
-          "include": "#argsList"
-        },
-        {
-          "include": "#annotation"
-        },
-        {
-          "include": "#comments"
-        },
-        {
-          "include": "#numeric"
-        }
-      ]
-    },
-    "userDefinedAttribute": {
-      "begin": "(?x)\n  ([a-z][A-Za-z0-9_]*) # field name\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  : # colon\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  ([A-Z][A-Za-z0-9_]*) # type name\n",
-      "beginCaptures": {
-        "1": {
-          "name": "entity.name"
-        },
-        "2": {
-          "name": "comment.block"
-        },
-        "3": {
-          "name": "comment.block"
-        },
-        "4": {
-          "name": "entity.name.type"
-        }
-      },
-      "end": "(?x)\n  (;|(?=((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*))\\}) # semicolon or end of block\n",
-      "patterns": [
-        {
-          "include": "#argsList"
-        },
-        {
-          "include": "#annotation"
-        },
-        {
-          "include": "#comments"
-        },
-        {
-          "include": "#numeric"
-        }
-      ]
-    },
-    "metadata": {
-      "patterns": [
-        {
-          "include": "#fullMetadata"
-        },
-        {
-          "include": "#shorthandMetadata"
-        },
-        {
-          "include": "#emptyMetadata"
-        }
-      ]
-    },
-    "shorthandMetadata": {
-      "begin": "(?x)\n  (\\#[a-z][A-Za-z0-9_]*) # hash followed by an identifier\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  \\[ # open shorthand\n",
-      "beginCaptures": {
-        "1": {
-          "name": "keyword"
-        },
-        "2": {
-          "name": "comment.block"
-        },
-        "3": {
-          "name": "comment.block"
-        },
-        "4": {
-          "name": "entity.name.type"
-        },
-        "5": {
-          "name": "comment.block"
-        }
-      },
-      "end": "(?x)\n  \\] # close shorthand\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  (;|(?=((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*))\\}) # semicolon or end of block\n",
-      "endCaptures": {
-        "1": {
-          "name": "comment.block"
-        }
-      },
-      "patterns": [
-        {
-          "include": "#comments"
-        },
-        {
-          "include": "#token"
-        },
-        {
-          "include": "#numeric"
-        }
-      ]
-    },
-    "fullMetadata": {
-      "begin": "(?x)\n  (\\#[a-z][A-Za-z0-9_]*) # hash followed by an identifier\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  \\( # open arg list\n",
-      "beginCaptures": {
-        "1": {
-          "name": "keyword"
-        },
-        "2": {
-          "name": "comment.block"
-        },
-        "3": {
-          "name": "comment.block"
-        },
-        "4": {
-          "name": "entity.name.type"
-        },
-        "5": {
-          "name": "comment.block"
-        }
-      },
-      "end": "(?x)\n  \\) # close arg list\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  (;|(?=((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*))\\}) # semicolon or end of block\n",
-      "endCaptures": {
-        "1": {
-          "name": "comment.block"
-        }
-      },
-      "patterns": [
-        {
-          "include": "#comments"
-        },
-        {
-          "include": "#token"
-        },
-        {
-          "include": "#numeric"
-        },
-        {
-          "include": "#param"
-        }
-      ]
-    },
-    "emptyMetadata": {
-      "match": "(?x)\n  (\\#[a-z][A-Za-z0-9_]*) # hash followed by an identifier\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  (;|(?=((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*))\\}) # semicolon or end of block\n",
-      "captures": {
-        "1": {
-          "name": "keyword"
-        }
-      }
-    },
-    "argsList": {
-      "begin": "\\(",
-      "end": "\\)",
-      "patterns": [
-        {
-          "include": "#comments"
-        },
-        {
-          "include": "#token"
-        },
-        {
-          "include": "#numeric"
-        },
-        {
-          "include": "#param"
-        }
-      ]
-    },
-    "param": {
-      "match": "(?x)\n  ([a-zA-Z_][a-zA-Z_0-9]*) # identifier name\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  : # colon\n",
-      "captures": {
-        "1": {
-          "name": "variable.parameter"
-        },
-        "2": {
-          "name": "comment.block"
-        }
-      }
-    },
-    "numeric": {
-      "match": "[-+]?\\d+(\\.\\d+)?",
-      "name": "constant.numeric"
-    }
-  }
+    "scopeName": "root.temple"
 }

--- a/syntaxes/temple.tmLanguage.json
+++ b/syntaxes/temple.tmLanguage.json
@@ -1,238 +1,253 @@
 {
-    "patterns": [
-        {
-            "include": "#comments"
-        },
-        {
-            "include": "#blockType"
-        },
-        {
-            "include": "#attribute"
-        },
-        {
-            "include": "#metadata"
-        }
-    ],
-    "repository": {
-        "annotation": {
-            "match": "@[a-z][A-Za-z0-9_]*",
-            "name": "keyword"
-        },
-        "argsList": {
-            "begin": "\\(",
-            "end": "\\)",
-            "patterns": [
-                {
-                    "include": "#comments"
-                },
-                {
-                    "include": "#token"
-                },
-                {
-                    "include": "#numeric"
-                },
-                {
-                    "include": "#param"
-                }
-            ]
-        },
-        "array": {
-            "begin": "[",
-            "captures": {
-                "0": {
-                    "name": "punctuation.paren"
-                }
-            },
-            "end": "]"
-        },
-        "attribute": {
-            "begin": "(?x)\n  ([a-z][A-Za-z0-9_]*) # field name\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  : # colon\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  ([A-Za-z][A-Za-z0-9_]*) # type name\n",
-            "beginCaptures": {
-                "1": {
-                    "name": "entity.name"
-                },
-                "2": {
-                    "name": "comment.block"
-                },
-                "3": {
-                    "name": "comment.block"
-                },
-                "4": {
-                    "name": "entity.name.type"
-                }
-            },
-            "end": "(?x)\n  (;|(?=((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*))\\}) # semicolon or end of block\n",
-            "patterns": [
-                {
-                    "include": "#argsList"
-                },
-                {
-                    "include": "#annotation"
-                },
-                {
-                    "include": "#comments"
-                },
-                {
-                    "include": "#numeric"
-                }
-            ]
-        },
-        "blockType": {
-            "captures": {
-                "1": {
-                    "name": "entity.name"
-                },
-                "2": {
-                    "name": "comment.block"
-                },
-                "3": {
-                    "name": "comment.block"
-                },
-                "4": {
-                    "name": "entity.name.type"
-                },
-                "5": {
-                    "name": "comment.block"
-                }
-            },
-            "match": "(?x)\n  ([A-Z][A-Za-z0-9_]*) # class name\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  : #colon\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  ([a-z][A-Za-z0-9_]*) # block type name\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  \\{ # open brace\n"
-        },
-        "comma": {
-            "captures": {
-                "0": {}
-            },
-            "match": ","
-        },
-        "comments": {
-            "patterns": [
-                {
-                    "match": "//.*",
-                    "name": "comment.line.double-slash"
-                },
-                {
-                    "match": "/\\*[\\s\\S]*?\\*/",
-                    "name": "comment.block"
-                }
-            ]
-        },
-        "emptyMetadata": {
-            "captures": {
-                "1": {
-                    "name": "keyword"
-                }
-            },
-            "match": "(?x)\n  (\\#[a-z][A-Za-z0-9_]*) # hash followed by an identifier\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  (;|(?=((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*))\\}) # semicolon or end of block\n"
-        },
-        "fullMetadata": {
-            "begin": "(?x)\n  (\\#[a-z][A-Za-z0-9_]*) # hash followed by an identifier\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  \\( # open arg list\n",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword"
-                },
-                "2": {
-                    "name": "comment.block"
-                },
-                "3": {
-                    "name": "comment.block"
-                },
-                "4": {
-                    "name": "entity.name.type"
-                },
-                "5": {
-                    "name": "comment.block"
-                }
-            },
-            "end": "(?x)\n  \\) # close arg list\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  (;|(?=((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*))\\}) # semicolon or end of block\n",
-            "endCaptures": {
-                "1": {
-                    "name": "comment.block"
-                }
-            },
-            "patterns": [
-                {
-                    "include": "#comments"
-                },
-                {
-                    "include": "#token"
-                },
-                {
-                    "include": "#numeric"
-                },
-                {
-                    "include": "#param"
-                }
-            ]
-        },
-        "metadata": {
-            "patterns": [
-                {
-                    "include": "#fullMetadata"
-                },
-                {
-                    "include": "#shorthandMetadata"
-                },
-                {
-                    "include": "#emptyMetadata"
-                }
-            ]
-        },
-        "numeric": {
-            "match": "[-+]?\\d+(\\.\\d+)?",
-            "name": "constant.numeric"
-        },
-        "numeric2": {
-            "match": "[-+]?\\d+(\\.\\d+)?",
-            "name": "keyword"
-        },
-        "param": {
-            "captures": {
-                "1": {
-                    "name": "variable.parameter"
-                },
-                "2": {
-                    "name": "comment.block"
-                },
-                "3": {}
-            },
-            "match": "(?x)\n  ([a-zA-Z_][a-zA-Z_0-9]*) # identifier name\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  : # colon\n"
-        },
-        "shorthandMetadata": {
-            "begin": "(?x)\n  (\\#[a-z][A-Za-z0-9_]*) # hash followed by an identifier\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  \\[ # open shorthand\n",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword"
-                },
-                "2": {
-                    "name": "comment.block"
-                },
-                "3": {
-                    "name": "comment.block"
-                },
-                "4": {
-                    "name": "entity.name.type"
-                },
-                "5": {
-                    "name": "comment.block"
-                }
-            },
-            "end": "(?x)\n  \\] # close shorthand\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  (;|(?=((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*))\\}) # semicolon or end of block\n",
-            "endCaptures": {
-                "1": {
-                    "name": "comment.block"
-                }
-            },
-            "patterns": [
-                {
-                    "include": "#comments"
-                },
-                {
-                    "include": "#token"
-                },
-                {
-                    "include": "#numeric"
-                }
-            ]
-        }
+  "scopeName": "root.temple",
+  "patterns": [
+    {
+      "include": "#comments"
     },
-    "scopeName": "root.temple"
+    {
+      "include": "#blockType"
+    },
+    {
+      "include": "#builtInAttribute"
+    },
+    {
+      "include": "#userDefinedAttribute"
+    },
+    {
+      "include": "#metadata"
+    }
+  ],
+  "repository": {
+    "blockType": {
+      "match": "(?x)\n  ([A-Z][A-Za-z0-9_]*) # class name\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  : #colon\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  (target|project|service|struct) # block type name\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  \\{ # open brace\n",
+      "captures": {
+        "1": {
+          "name": "entity.name.class"
+        },
+        "2": {
+          "name": "comment.block"
+        },
+        "3": {
+          "name": "comment.block"
+        },
+        "4": {
+          "name": "keyword.other"
+        },
+        "5": {
+          "name": "comment.block"
+        }
+      }
+    },
+    "annotation": {
+      "match": "@[a-z][A-Za-z0-9_]*",
+      "name": "keyword"
+    },
+    "comments": {
+      "patterns": [
+        {
+          "match": "//.*",
+          "name": "comment.line.double-slash"
+        },
+        {
+          "match": "/\\*[\\s\\S]*?\\*/",
+          "name": "comment.block"
+        }
+      ]
+    },
+    "builtInAttribute": {
+      "begin": "(?x)\n  ([a-z][A-Za-z0-9_]*) # field name\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  : # colon\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  (bool|string|int|float|datetime|date|time|data) # type name\n",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name"
+        },
+        "2": {
+          "name": "comment.block"
+        },
+        "3": {
+          "name": "comment.block"
+        },
+        "4": {
+          "name": "support.type"
+        }
+      },
+      "end": "(?x)\n  (;|(?=((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*))\\}) # semicolon or end of block\n",
+      "patterns": [
+        {
+          "include": "#argsList"
+        },
+        {
+          "include": "#annotation"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#numeric"
+        }
+      ]
+    },
+    "userDefinedAttribute": {
+      "begin": "(?x)\n  ([a-z][A-Za-z0-9_]*) # field name\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  : # colon\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  ([A-Z][A-Za-z0-9_]*) # type name\n",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name"
+        },
+        "2": {
+          "name": "comment.block"
+        },
+        "3": {
+          "name": "comment.block"
+        },
+        "4": {
+          "name": "entity.name.type"
+        }
+      },
+      "end": "(?x)\n  (;|(?=((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*))\\}) # semicolon or end of block\n",
+      "patterns": [
+        {
+          "include": "#argsList"
+        },
+        {
+          "include": "#annotation"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#numeric"
+        }
+      ]
+    },
+    "metadata": {
+      "patterns": [
+        {
+          "include": "#fullMetadata"
+        },
+        {
+          "include": "#shorthandMetadata"
+        },
+        {
+          "include": "#emptyMetadata"
+        }
+      ]
+    },
+    "shorthandMetadata": {
+      "begin": "(?x)\n  (\\#[a-z][A-Za-z0-9_]*) # hash followed by an identifier\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  \\[ # open shorthand\n",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword"
+        },
+        "2": {
+          "name": "comment.block"
+        },
+        "3": {
+          "name": "comment.block"
+        },
+        "4": {
+          "name": "entity.name.type"
+        },
+        "5": {
+          "name": "comment.block"
+        }
+      },
+      "end": "(?x)\n  \\] # close shorthand\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  (;|(?=((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*))\\}) # semicolon or end of block\n",
+      "endCaptures": {
+        "1": {
+          "name": "comment.block"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#token"
+        },
+        {
+          "include": "#numeric"
+        }
+      ]
+    },
+    "fullMetadata": {
+      "begin": "(?x)\n  (\\#[a-z][A-Za-z0-9_]*) # hash followed by an identifier\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  \\( # open arg list\n",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword"
+        },
+        "2": {
+          "name": "comment.block"
+        },
+        "3": {
+          "name": "comment.block"
+        },
+        "4": {
+          "name": "entity.name.type"
+        },
+        "5": {
+          "name": "comment.block"
+        }
+      },
+      "end": "(?x)\n  \\) # close arg list\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  (;|(?=((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*))\\}) # semicolon or end of block\n",
+      "endCaptures": {
+        "1": {
+          "name": "comment.block"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#token"
+        },
+        {
+          "include": "#numeric"
+        },
+        {
+          "include": "#param"
+        }
+      ]
+    },
+    "emptyMetadata": {
+      "match": "(?x)\n  (\\#[a-z][A-Za-z0-9_]*) # hash followed by an identifier\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  (;|(?=((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*))\\}) # semicolon or end of block\n",
+      "captures": {
+        "1": {
+          "name": "keyword"
+        }
+      }
+    },
+    "argsList": {
+      "begin": "\\(",
+      "end": "\\)",
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#token"
+        },
+        {
+          "include": "#numeric"
+        },
+        {
+          "include": "#param"
+        }
+      ]
+    },
+    "param": {
+      "match": "(?x)\n  ([a-zA-Z_][a-zA-Z_0-9]*) # identifier name\n  ((?:\\s*(?:/\\*[\\s\\S]*?\\*/|//.*\\n))*\\s*) # space/comment?\n  : # colon\n",
+      "captures": {
+        "1": {
+          "name": "variable.parameter"
+        },
+        "2": {
+          "name": "comment.block"
+        }
+      }
+    },
+    "numeric": {
+      "match": "[-+]?\\d+(\\.\\d+)?",
+      "name": "constant.numeric"
+    }
+  }
 }

--- a/syntaxes/temple.tmlanguage.yml
+++ b/syntaxes/temple.tmlanguage.yml
@@ -5,7 +5,8 @@ scopeName: root.temple
 patterns:
   - include: '#comments'
   - include: '#blockType'
-  - include: '#attribute'
+  - include: '#builtInAttribute'
+  - include: '#userDefinedAttribute'
   - include: '#metadata'
 
 repository:
@@ -16,38 +17,57 @@ repository:
         ((?:\s*(?:/\*[\s\S]*?\*/|//.*\n))*\s*) # space/comment?
         : #colon
         ((?:\s*(?:/\*[\s\S]*?\*/|//.*\n))*\s*) # space/comment?
-        ([a-z][A-Za-z0-9_]*) # block type name
+        (target|project|service|struct) # block type name
         ((?:\s*(?:/\*[\s\S]*?\*/|//.*\n))*\s*) # space/comment?
         \{ # open brace
     captures:
-      1: { name: entity.name }
+      1: { name: entity.name.class }
       2: { name: comment.block }
       3: { name: comment.block }
-      4: { name: entity.name.type }
+      4: { name: keyword.other }
       5: { name: comment.block }
 
   annotation:
     match: '@[a-z][A-Za-z0-9_]*'
     name: keyword
 
-  comma:
-    match: ','
-    captures:
-      0: {}
   comments:
     patterns:
       - match: //.*
         name: comment.line.double-slash
       - match: '/\*[\s\S]*?\*/'
         name: comment.block
-  attribute:
+
+  builtInAttribute:
     begin: |
       (?x)
         ([a-z][A-Za-z0-9_]*) # field name
         ((?:\s*(?:/\*[\s\S]*?\*/|//.*\n))*\s*) # space/comment?
         : # colon
         ((?:\s*(?:/\*[\s\S]*?\*/|//.*\n))*\s*) # space/comment?
-        ([A-Za-z][A-Za-z0-9_]*) # type name
+        (bool|string|int|float|datetime|date|time|data) # type name
+    beginCaptures:
+      1: { name: entity.name }
+      2: { name: comment.block }
+      3: { name: comment.block }
+      4: { name: support.type }
+    end: |
+      (?x)
+        (;|(?=((?:\s*(?:/\*[\s\S]*?\*/|//.*\n))*\s*))\}) # semicolon or end of block
+    patterns:
+      - include: '#argsList'
+      - include: '#annotation'
+      - include: '#comments'
+      - include: '#numeric'
+
+  userDefinedAttribute:
+    begin: |
+      (?x)
+        ([a-z][A-Za-z0-9_]*) # field name
+        ((?:\s*(?:/\*[\s\S]*?\*/|//.*\n))*\s*) # space/comment?
+        : # colon
+        ((?:\s*(?:/\*[\s\S]*?\*/|//.*\n))*\s*) # space/comment?
+        ([A-Z][A-Za-z0-9_]*) # type name
     beginCaptures:
       1: { name: entity.name }
       2: { name: comment.block }
@@ -61,11 +81,13 @@ repository:
       - include: '#annotation'
       - include: '#comments'
       - include: '#numeric'
+
   metadata:
     patterns:
       - include: '#fullMetadata'
       - include: '#shorthandMetadata'
       - include: '#emptyMetadata'
+
   shorthandMetadata:
     begin: |
       (?x)
@@ -89,6 +111,7 @@ repository:
       - include: '#comments'
       - include: '#token'
       - include: '#numeric'
+
   fullMetadata:
     begin: |
       (?x)
@@ -113,6 +136,7 @@ repository:
       - include: '#token'
       - include: '#numeric'
       - include: '#param'
+
   emptyMetadata:
     match: |
       (?x)
@@ -121,6 +145,7 @@ repository:
         (;|(?=((?:\s*(?:/\*[\s\S]*?\*/|//.*\n))*\s*))\}) # semicolon or end of block
     captures:
       1: { name: keyword }
+
   argsList:
     begin: '\('
     end: '\)'
@@ -129,6 +154,7 @@ repository:
       - include: '#token'
       - include: '#numeric'
       - include: '#param'
+
   param:
     match: |
       (?x)
@@ -138,15 +164,7 @@ repository:
     captures:
       1: { name: variable.parameter }
       2: { name: comment.block }
-      3: {}
+
   numeric:
     match: '[-+]?\d+(\.\d+)?'
     name: constant.numeric
-  numeric2:
-    match: '[-+]?\d+(\.\d+)?'
-    name: keyword
-  array:
-    begin: '['
-    end: ']'
-    captures:
-      0: { name: punctuation.paren }

--- a/syntaxes/temple.tmlanguage.yml
+++ b/syntaxes/temple.tmlanguage.yml
@@ -72,7 +72,7 @@ repository:
       1: { name: entity.name }
       2: { name: comment.block }
       3: { name: comment.block }
-      4: { name: entity.name.type }
+      4: { name: entity.name.class }
     end: |
       (?x)
         (;|(?=((?:\s*(?:/\*[\s\S]*?\*/|//.*\n))*\s*))\}) # semicolon or end of block


### PR DESCRIPTION
My VSCode theme didn't like the names assigned to the types, so I've updated them to follow https://www.sublimetext.com/docs/3/scope_naming.html#support, using our types as the "base framework".

- Differentiated between user defined types (start with uppercase) and our types (from a predefined list).
- Tidy up unused things

Also, sorry about the big JSON changes, couldn't work out your command @xsanda, so I opted for:

```
cat temple.tmlanguage.yml | ruby -ryaml -rjson -e 'puts(JSON.pretty_generate(YAML.load(ARGF.read)))' >! temple.tmLanguage.json
```

Before:
<img width="684" alt="before" src="https://user-images.githubusercontent.com/16157582/76168070-c13edb00-6163-11ea-920c-4c86ed479a37.png">

After:
<img width="664" alt="after" src="https://user-images.githubusercontent.com/16157582/76168071-c2700800-6163-11ea-8964-71bcab556b8a.png">


